### PR TITLE
Fix copying of terms.

### DIFF
--- a/script.js
+++ b/script.js
@@ -84,7 +84,7 @@ function setUpCopyButtons() {
     ZeroClipboard.setDefaults({ moviePath: "/zeroclipboard.swf", forceHandCursor: true, hoverClass: 'hover' });
     $('.uri.copy').each(function () {
       var $uri = $(this);
-      $uri.before(createCopyButton($uri.text()), ' ');
+      $uri.before(createCopyButton($uri.text() + $uri.next('.term').text()), ' ');
     }).removeClass('copy');
     $('pre.source.copy').each(function () {
       $('.footer').prepend($('<p>').append(createCopyButton($(this).text().trim(),

--- a/templates/record-lookup-uri.php
+++ b/templates/record-lookup-uri.php
@@ -1,5 +1,5 @@
       <h2 class="expansion">
-        <span class="uri copy"><?php e($uri); ?></span><?php e(@$reference); ?>
+        <span class="uri copy"><?php e($uri); ?></span><span class="term"><?php e(@$reference); ?></span>
         <a class="namespace-link no-caption" href="<?php e($uri . $reference); ?>" rel="nofollow"><img src="images/link.png" alt="link to <?php echo $reference ? 'term' : 'namespace'; ?> URI" title="go to the <?php echo $reference ? 'term' : 'namespace'; ?> URI" /></a>
 <?php if (@$show_vote_links) { ?>
         <span class="toolbox">


### PR DESCRIPTION
When creating the copy button, there was apparently one case we missed:
trying to copy terms from pages such as http://xmlns.com/foaf/0.1/ only copies the namespace.
The expected behavior would be to copy the whole URL of the term.

This pull request should fix this. (But please test.)

PS I couldn't simply extend the range of the `<span class="uri copy">`,
because the voting script relies on `.uri` being the namespace.
