### PR TITLE
Do not escape forward slashes

### DIFF
--- a/templates/format/json.php
+++ b/templates/format/json.php
@@ -4,7 +4,7 @@ foreach ($namespaces as $ns) {
     if ($i++ > 0) echo ",";
     echo "\n  \"$ns[prefix]\": ";
     if ($ns['uri']) {
-        echo json_encode($ns['uri']);
+        echo json_encode($ns['uri'], JSON_UNESCAPED_SLASHES);
     } else {
         echo "null";
     }


### PR DESCRIPTION
This requires PHP 5.4 to work.

Without this, URLs in JSON look like this `http:\/\/www.example.com\/...` which makes them very hard to read.
