### PR TITLE
Make JSON-LD context more discoverable

### DIFF
--- a/lib/site.class.php
+++ b/lib/site.class.php
@@ -114,6 +114,7 @@ class Site {
                 'popular' => array('popular', 'rel' => 'rdfs:seeAlso'),
                 'latest' => array('latest', 'rel' => 'rdfs:seeAlso'),
                 'about' => array('about', 'rel' => 'rdfs:seeAlso'),
+                'json-ld context' => array('context', 'rel' => 'rdfs:seeAlso')
         );
     }
 


### PR DESCRIPTION
Make JSON-LD context more discoverable by linking to it prominently on the index page.
