### PR TITLE
Allow an underscore in the prefix name

### DIFF
--- a/lib/namespaces.class.php
+++ b/lib/namespaces.class.php
@@ -159,7 +159,7 @@ class Namespaces {
     }
 
     function get_prefix_regex() {
-        return "[a-z][a-z0-9]{1,9}";
+        return "[a-z][a-z0-9]{1,9}(?:_[a-z0-9]{1,7})?";
     }
 
     function is_valid_prefix_syntax($prefix) {


### PR DESCRIPTION
Closes #24 

Tested via https://regex101.com/ with PHP7.3+ selected.

An alternative return value would be `(?=.{1,11}$)[a-z][a-z0-9]*(?:_[a-z0-9]+)?` and that would limit the whole prefix to 11 chars.