### PR TITLE
Add the Bioregistry to list of tools

### DIFF
--- a/templates/page-users.php
+++ b/templates/page-users.php
@@ -4,5 +4,6 @@
     <ul>
       <li><a href="https://github.com/TriplyDB/Yasgui">YASGUI</a> Yet Another SPARQL GUI</li>
       <li><a href="https://marketplace.visualstudio.com/items?itemName=umutsims.prefix-cc">prefix.cc extension for Visual Studio Code</a> by Umutcan Şimşek</li>
+      <li><a href="https://github.com/biopragmatics/bioregistry">The Bioregistry</a></li>
     </ul>
   </div>


### PR DESCRIPTION
This PR adds the Bioregistry (https://github.com/biopragmatics/bioregistry / https://bioregistry.io) to the list of tools using Prefix.cc.

Short summary: the Bioregistry is also keeping track of prefixes useful in the biomedical domain (with some spillover from more general semantic web stuff), it automatically aligns its prefixes with Prefix.cc when possible, and imports URI prefixes from Prefix.cc